### PR TITLE
notification to other users for new messages

### DIFF
--- a/app/assets/stylesheets/components/_navbar.scss
+++ b/app/assets/stylesheets/components/_navbar.scss
@@ -10,3 +10,14 @@
 .navbar-lewagon .navbar-brand img {
   width: 40px;
 }
+
+#nav-messages {
+  display: flex;
+  align-items: center;
+}
+
+.notification-new-message {
+  color: red;
+  font-size: 0.5rem;
+  display: none;
+}

--- a/app/channels/notification_channel.rb
+++ b/app/channels/notification_channel.rb
@@ -1,0 +1,6 @@
+class NotificationChannel < ApplicationCable::Channel
+  def subscribed
+    user = User.find(params[:id])
+    stream_for user
+  end
+end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -10,6 +10,7 @@ class MessagesController < ApplicationController
         @chatroom,
         render_to_string(partial: "message", locals: { message: @message })
       )
+      notify_other_users
       redirect_to chatroom_path(@chatroom, anchor: "message-#{@message.id}")
     else
       render 'chatroom/show'
@@ -17,6 +18,16 @@ class MessagesController < ApplicationController
   end
 
   private
+
+  def notify_other_users
+    users = User.all - [current_user]
+    users.each do |user|
+      NotificationChannel.broadcast_to(
+        user,
+        "A new message!"
+      )
+    end
+  end
 
   def message_params
     params.require(:message).permit(:content)

--- a/app/javascript/channels/notification_channel.js
+++ b/app/javascript/channels/notification_channel.js
@@ -1,0 +1,20 @@
+import consumer from "./consumer";
+
+const initNotificationCable = () => {
+  const messagesContainer = document.getElementById('messages');
+  // We are NOT on the messages page, so show notifications
+  if (!messagesContainer) {
+    const messagesNav = document.getElementById('nav-messages');
+    const userId = messagesNav.dataset.userId;
+
+    consumer.subscriptions.create({ channel: "NotificationChannel", id: userId }, {
+      received(data) {
+        console.log(data)
+        const notificationDot = messagesNav.querySelector('.notification-new-message');
+        notificationDot.style.display = 'block';
+      },
+    });
+  }
+}
+
+export { initNotificationCable };

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -28,9 +28,11 @@ import "bootstrap";
 // Internal imports, e.g:
 // import { initSelect2 } from '../components/init_select2';
 import { initChatroomCable } from '../channels/chatroom_channel';
+import { initNotificationCable } from '../channels/notification_channel';
 
 document.addEventListener('turbolinks:load', () => {
   // Call your functions here, e.g:
   // initSelect2();
   initChatroomCable();
+  initNotificationCable();
 });

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -15,7 +15,10 @@
           <%= link_to "Home", "#", class: "nav-link" %>
         </li>
         <li class="nav-item">
-          <%= link_to "Messages", "#", class: "nav-link" %>
+          <%= link_to "#", class: "nav-link", id: 'nav-messages', data: { user_id: current_user.id } do %>
+            Messages&nbsp;
+            <span class="notification-new-message"><i class="fas fa-circle"></i></span>
+          <% end %>
         </li>
         <li class="nav-item dropdown">
           <strong><%= current_user.nickname %></strong>


### PR DESCRIPTION
A very simple 'notification' feature.

- When a new message is created, send a notification to every user except for the user who created the message.
- On the client side, when a new notification is received, the JS code will check whether the user is on a chatroom page. If so, no further action will be taken.
- But if the user is *not* on a chatroom page, the notification dot will be shown.
- This uses some simple CSS to show an element on the page which is rendered as hidden by default.

### Extensions
- Ideally the notifications should be sent only to the relevant users, not all users except the author of the message.
- Currently, the dot disappears when the page is reloaded. Ideally the view code for the navbar should render the dot as *visible* on the server whenever the user has unread messages. This means that the notification dot will 'stick' even when the page is reloaded.
- This would mean that the app will need to keep track of when a user has read a message -- this would imply a schema change. If your app has messages shared between users, that should be quite easy to implement: just add a single field to record when/if the message was read, and give it a relevant value when you have determined that the recipient has read the message.
